### PR TITLE
override columns

### DIFF
--- a/lib/go/gframer/gframer.go
+++ b/lib/go/gframer/gframer.go
@@ -20,6 +20,7 @@ type FramerOptions struct {
 	FrameName           string
 	ExecutedQueryString string
 	Columns             []ColumnSelector
+	OverrideColumns     []ColumnSelector
 }
 
 func noOperation(x interface{}) {}
@@ -120,7 +121,20 @@ func sliceToFrame(name string, input []interface{}, options FramerOptions) (fram
 						}
 					}
 				}
-				for _, k := range sortedKeys(results) {
+				keys := sortedKeys(results)
+				if len(options.OverrideColumns) > 0 {
+					options.Columns = []ColumnSelector{}
+					for _, key := range keys {
+						overriddenColumn := ColumnSelector{Selector: key}
+						for _, oc := range options.OverrideColumns {
+							if oc.Selector == key {
+								overriddenColumn = oc
+							}
+						}
+						options.Columns = append(options.Columns, overriddenColumn)
+					}
+				}
+				for _, k := range keys {
 					if results[k] != nil {
 						o := []interface{}{}
 						for i := 0; i < len(input); i++ {

--- a/lib/go/jsonframer/json_test.go
+++ b/lib/go/jsonframer/json_test.go
@@ -21,6 +21,7 @@ func TestJsonStringToFrame(t *testing.T) {
 		refId          string
 		rootSelector   string
 		columns        []jsonframer.ColumnSelector
+		overrides      []jsonframer.ColumnSelector
 		wantFrame      *data.Frame
 		wantErr        error
 	}{
@@ -246,13 +247,36 @@ func TestJsonStringToFrame(t *testing.T) {
 				"c": $eval("", $v.b).c
 			  }})`,
 		},
+		{
+			name: "timestamp overrides",
+			responseString: `[
+				{ "foo" : "2011-01-01T00:00:00.000Z", "bar1": 1325376000000, "baz" : true },
+				{ "foo" : "2012-01-01T00:00:00.000Z", "bar1": 1356998400000, "baz" : false}
+			]`,
+			overrides: []jsonframer.ColumnSelector{
+				{Selector: "foo", Type: "timestamp"},
+			},
+		},
+		{
+			name: "field overrides",
+			responseString: `[
+				{ "foo" : "2011-01-01T00:00:00.000Z", "bar1": 1325376000000, "baz" : true },
+				{ "foo" : "2012-01-01T00:00:00.000Z", "bar1": 1356998400000, "baz" : false , "num": 12, "bool": false, "str": "hello", "nullf": null }
+			]`,
+			overrides: []jsonframer.ColumnSelector{
+				{Selector: "foo", Type: "timestamp"},
+				{Selector: "bar1", Type: "string"},
+				{Selector: "baz", Type: "string"},
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			gotFrame, err := jsonframer.ToFrame(tt.responseString, jsonframer.FramerOptions{
-				FrameName:    tt.refId,
-				RootSelector: tt.rootSelector,
-				Columns:      tt.columns,
+				FrameName:       tt.refId,
+				RootSelector:    tt.rootSelector,
+				Columns:         tt.columns,
+				OverrideColumns: tt.overrides,
 			})
 			if tt.wantErr != nil {
 				require.NotNil(t, err)

--- a/lib/go/jsonframer/jsonframer.go
+++ b/lib/go/jsonframer/jsonframer.go
@@ -20,11 +20,12 @@ const (
 )
 
 type FramerOptions struct {
-	FramerType   FramerType // `gjson` | `sqlite3`
-	SQLite3Query string
-	FrameName    string
-	RootSelector string
-	Columns      []ColumnSelector
+	FramerType      FramerType // `gjson` | `sqlite3`
+	SQLite3Query    string
+	FrameName       string
+	RootSelector    string
+	Columns         []ColumnSelector
+	OverrideColumns []ColumnSelector
 }
 
 type ColumnSelector struct {
@@ -141,12 +142,22 @@ func getFrameFromResponseString(responseString string, options FramerOptions) (f
 			TimeFormat: c.TimeFormat,
 		})
 	}
+	overrides := []gframer.ColumnSelector{}
+	for _, c := range options.OverrideColumns {
+		overrides = append(overrides, gframer.ColumnSelector{
+			Alias:      c.Alias,
+			Selector:   c.Selector,
+			Type:       c.Type,
+			TimeFormat: c.TimeFormat,
+		})
+	}
 	return gframer.ToDataFrame(out, gframer.FramerOptions{
-		FrameName: options.FrameName,
-		Columns:   columns,
+		FrameName:       options.FrameName,
+		Columns:         columns,
+		OverrideColumns: overrides,
 	})
 }
 
-func convertFieldValueType(input interface{}, col ColumnSelector) interface{} {
+func convertFieldValueType(input interface{}, _ ColumnSelector) interface{} {
 	return input
 }

--- a/lib/go/jsonframer/testdata/field_overrides.jsonc
+++ b/lib/go/jsonframer/testdata/field_overrides.jsonc
@@ -1,0 +1,115 @@
+//  🌟 This was machine generated.  Do not edit. 🌟
+//  
+//  Frame[0] 
+//  Name: 
+//  Dimensions: 7 Fields by 2 Rows
+//  +-----------------+-----------------+---------------+-------------------------------+-----------------+------------------+-----------------+
+//  | Name: bar1      | Name: baz       | Name: bool    | Name: foo                     | Name: nullf     | Name: num        | Name: str       |
+//  | Labels:         | Labels:         | Labels:       | Labels:                       | Labels:         | Labels:          | Labels:         |
+//  | Type: []*string | Type: []*string | Type: []*bool | Type: []*time.Time            | Type: []*string | Type: []*float64 | Type: []*string |
+//  +-----------------+-----------------+---------------+-------------------------------+-----------------+------------------+-----------------+
+//  | 1.325376e+12    | true            | null          | 2011-01-01 00:00:00 +0000 UTC | null            | null             | null            |
+//  | 1.3569984e+12   | false           | false         | 2012-01-01 00:00:00 +0000 UTC | null            | 12               | hello           |
+//  +-----------------+-----------------+---------------+-------------------------------+-----------------+------------------+-----------------+
+//  
+//  
+//  🌟 This was machine generated.  Do not edit. 🌟
+{
+  "status": 200,
+  "frames": [
+    {
+      "schema": {
+        "fields": [
+          {
+            "name": "bar1",
+            "type": "string",
+            "typeInfo": {
+              "frame": "string",
+              "nullable": true
+            }
+          },
+          {
+            "name": "baz",
+            "type": "string",
+            "typeInfo": {
+              "frame": "string",
+              "nullable": true
+            }
+          },
+          {
+            "name": "bool",
+            "type": "boolean",
+            "typeInfo": {
+              "frame": "bool",
+              "nullable": true
+            }
+          },
+          {
+            "name": "foo",
+            "type": "time",
+            "typeInfo": {
+              "frame": "time.Time",
+              "nullable": true
+            }
+          },
+          {
+            "name": "nullf",
+            "type": "string",
+            "typeInfo": {
+              "frame": "string",
+              "nullable": true
+            }
+          },
+          {
+            "name": "num",
+            "type": "number",
+            "typeInfo": {
+              "frame": "float64",
+              "nullable": true
+            }
+          },
+          {
+            "name": "str",
+            "type": "string",
+            "typeInfo": {
+              "frame": "string",
+              "nullable": true
+            }
+          }
+        ]
+      },
+      "data": {
+        "values": [
+          [
+            "1.325376e+12",
+            "1.3569984e+12"
+          ],
+          [
+            "true",
+            "false"
+          ],
+          [
+            null,
+            false
+          ],
+          [
+            1293840000000,
+            1325376000000
+          ],
+          [
+            null,
+            null
+          ],
+          [
+            null,
+            12
+          ],
+          [
+            null,
+            "hello"
+          ]
+        ]
+      }
+    }
+  ]
+}

--- a/lib/go/jsonframer/testdata/timestamp_overrides.jsonc
+++ b/lib/go/jsonframer/testdata/timestamp_overrides.jsonc
@@ -1,0 +1,67 @@
+//  🌟 This was machine generated.  Do not edit. 🌟
+//  
+//  Frame[0] 
+//  Name: 
+//  Dimensions: 3 Fields by 2 Rows
+//  +------------------+---------------+-------------------------------+
+//  | Name: bar1       | Name: baz     | Name: foo                     |
+//  | Labels:          | Labels:       | Labels:                       |
+//  | Type: []*float64 | Type: []*bool | Type: []*time.Time            |
+//  +------------------+---------------+-------------------------------+
+//  | 1.325376e+12     | true          | 2011-01-01 00:00:00 +0000 UTC |
+//  | 1.3569984e+12    | false         | 2012-01-01 00:00:00 +0000 UTC |
+//  +------------------+---------------+-------------------------------+
+//  
+//  
+//  🌟 This was machine generated.  Do not edit. 🌟
+{
+  "status": 200,
+  "frames": [
+    {
+      "schema": {
+        "fields": [
+          {
+            "name": "bar1",
+            "type": "number",
+            "typeInfo": {
+              "frame": "float64",
+              "nullable": true
+            }
+          },
+          {
+            "name": "baz",
+            "type": "boolean",
+            "typeInfo": {
+              "frame": "bool",
+              "nullable": true
+            }
+          },
+          {
+            "name": "foo",
+            "type": "time",
+            "typeInfo": {
+              "frame": "time.Time",
+              "nullable": true
+            }
+          }
+        ]
+      },
+      "data": {
+        "values": [
+          [
+            1325376000000,
+            1356998400000
+          ],
+          [
+            true,
+            false
+          ],
+          [
+            1293840000000,
+            1325376000000
+          ]
+        ]
+      }
+    }
+  ]
+}


### PR DESCRIPTION
Allow JSONFramer, GFramer to set override columns. This will help to define/modify field type only for specified columns and no need to specify all the column names